### PR TITLE
Added proxy support

### DIFF
--- a/golang/index.go
+++ b/golang/index.go
@@ -89,14 +89,14 @@ func main() {
 			return
 		}
 
-		// edits.starts
+		
 		rawProxy := mytlsrequest.Options.Proxy
 		if rawProxy != "" {
 			proxyUrl, _ := url.Parse(rawProxy)
 			proxy := http.ProxyURL(proxyUrl)
 			tr.Proxy = proxy
 		}
-		// edits.ends
+		
 
 		client := &http.Client{Transport: tr}
 

--- a/golang/index.go
+++ b/golang/index.go
@@ -22,6 +22,7 @@ type myTLSRequest struct {
 		Headers map[string]string `json:"headers"`
 		Body string `json:"body"`
 		Ja3 string `json:"ja3"`
+		Proxy string  `json:"proxy"`
 	} `json:"options"`
 }
 
@@ -87,6 +88,17 @@ func main() {
 			log.Print(mytlsrequest.RequestID + "Request_Id_On_The_Left" + err.Error())
 			return
 		}
+
+		// edits.starts
+		rawProxy := mytlsrequest.Options.Proxy
+		if rawProxy != "" { 
+			proxyUrl, _ := url.Parse(rawProxy)
+		log.Print(rawProxy)
+		// log.Print(err)
+			proxy := http.ProxyURL(proxyUrl)
+			tr.Proxy = proxy
+		}
+		// edits.ends
 
 		client := &http.Client{Transport: tr}
 

--- a/golang/index.go
+++ b/golang/index.go
@@ -91,9 +91,8 @@ func main() {
 
 		// edits.starts
 		rawProxy := mytlsrequest.Options.Proxy
-		if rawProxy != "" { 
+		if rawProxy != "" {
 			proxyUrl, _ := url.Parse(rawProxy)
-		// log.Print(err)
 			proxy := http.ProxyURL(proxyUrl)
 			tr.Proxy = proxy
 		}
@@ -132,7 +131,7 @@ func main() {
 			if name == "Set-Cookie" {
 				headers[name] = strings.Join(values, "/,/")
 			} else {
-				for _, value := range values {		
+				for _, value := range values {
 					headers[name] = value
 				}
 			}
@@ -147,7 +146,7 @@ func main() {
 			log.Print(mytlsrequest.RequestID + "Request_Id_On_The_Left" + err.Error())
 			return
 		}
-		
+
 		err = c.WriteMessage(websocket.TextMessage, data)
 		if err != nil {
 			log.Print(mytlsrequest.RequestID + "Request_Id_On_The_Left" + err.Error())

--- a/golang/index.go
+++ b/golang/index.go
@@ -93,7 +93,6 @@ func main() {
 		rawProxy := mytlsrequest.Options.Proxy
 		if rawProxy != "" { 
 			proxyUrl, _ := url.Parse(rawProxy)
-		log.Print(rawProxy)
 		// log.Print(err)
 			proxy := http.ProxyURL(proxyUrl)
 			tr.Proxy = proxy

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export interface MyTlsRequestOptions {
   };
   body?: string;
   ja3?: string;
+  proxy?: string;
 }
 
 export interface MyTlsResponse {
@@ -130,6 +131,7 @@ const initMyTls = async (
             if (!options.ja3)
               options.ja3 = '771,255-49195-49199-49196-49200-49171-49172-156-157-47-53,0-10-11-13,23-24,0';
             if (!options.body) options.body = '';
+	    if (!options.proxy) options.proxy = '';
 
             instance.request(requestId, {
               url,


### PR DESCRIPTION
Added proxy support

```javascript
const initMyTls = require('mytls');

// Typescript: import initMyTls from 'mytls';

(async () => {
  const myTls = await initMyTls();

  const response = await myTls('https://ipv4.icanhazip.com', {
    body: '',
    headers: {
      'user-agent': 'customheaders',
    },
    ja3: '771,255-49195-49199-49196-49200-49171-49172-156-157-47-53,0-10-11-13,23-24,0',
   proxy: 'http://random:passwd@localhost:8180',
  });
 console.log('new_ip:', response.body)
})();

```


